### PR TITLE
dep: update from Node12 to Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
     default: '.'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'start.js'
 branding:
   icon: 'arrow-up-circle'


### PR DESCRIPTION
The GitHub Actions workflow gives the following annotation while running the action. 

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-js/push

So we need to update Node version from 12 to 16.