### PR TITLE
feat: add support for amend input

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ jobs:
 | message        | string  | 'chore: autopublish ${date}' | Commit message. |
 | branch         | string  | 'main'                    | Destination branch to push changes. |
 | empty          | boolean | false                       | Allow empty commit. |
+| amend          | boolean | false                       | Determines if the commit should be amended. Needs to be used with `force` input to force push the amended commit. |
 | force          | boolean | false                       | Determines if force push is used. |
 | tags           | boolean | false                       | Determines if `--tags` is used. |
 | directory      | string  | '.'                         | Directory to change to before pushing. |

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
   empty:
     description: 'Allow empty commit'
     required: false
+  amend:
+    description: 'Determines if the commit should be amended'
+    required: false
+    default: 'false'
   force:
     description: 'Determines if force push is used'
     required: false

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,7 @@ INPUT_COAUTHOR_EMAIL=${INPUT_COAUTHOR_EMAIL:-''}
 INPUT_COAUTHOR_NAME=${INPUT_COAUTHOR_NAME:-''}
 INPUT_MESSAGE=${INPUT_MESSAGE:-"chore: autopublish ${timestamp}"}
 INPUT_BRANCH=${INPUT_BRANCH:-master}
+INPUT_AMEND=${INPUT_AMEND:-false}
 INPUT_FORCE=${INPUT_FORCE:-false}
 INPUT_TAGS=${INPUT_TAGS:-false}
 INPUT_EMPTY=${INPUT_EMPTY:-false}
@@ -23,6 +24,10 @@ echo "Push to branch $INPUT_BRANCH";
 
 if ${INPUT_EMPTY}; then
     _EMPTY='--allow-empty'
+fi
+
+if ${INPUT_AMEND}; then
+    _AMEND='--amend --no-edit'
 fi
 
 if ${INPUT_FORCE}; then
@@ -43,7 +48,16 @@ git config --local user.name "${INPUT_AUTHOR_NAME}"
 
 git add -A
 
-if [ -n "${INPUT_COAUTHOR_EMAIL}" ] && [ -n "${INPUT_COAUTHOR_NAME}" ]; then
+if ${INPUT_AMEND}; then
+    if [ -n "${INPUT_COAUTHOR_EMAIL}" ] && [ -n "${INPUT_COAUTHOR_NAME}" ]; then
+        git commit ${_AMEND} -m "${INPUT_MESSAGE}
+
+    Co-authored-by: ${INPUT_COAUTHOR_NAME} <${INPUT_COAUTHOR_EMAIL}>" || exit 0
+    else
+    git commit ${_AMEND} -m "${INPUT_MESSAGE}" $_EMPTY || exit 0
+    fi
+
+elif [ -n "${INPUT_COAUTHOR_EMAIL}" ] && [ -n "${INPUT_COAUTHOR_NAME}" ]; then
     git commit -m "${INPUT_MESSAGE}
     
 


### PR DESCRIPTION
Amend input is added to allow amending the last commit instead of creating a new one. (#8)

Features:

- [x] Users can now amend the last commit instead of creating a new one.
- [x] Amend input can be used with message input.
- [x] Amend input can be used with co-author name and co-author email input.
- [x] Amend input can be used with force input.

Note: You need to use amend input with force input. Both inputs need to be set to true to force push the amended commit. Otherwise, the action will fail. This note is added to the README.md file.
