### PR TITLE
fix: bump nodejs version to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ inputs:
     required: false
     default: '.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'start.js'
 branding:
   icon: 'arrow-up-circle'


### PR DESCRIPTION
Since Node 16 has reached the end of its life, this action needs to be updated to Node 20. Here it is!

Close #25 